### PR TITLE
Mute track

### DIFF
--- a/examples/minimal-react/package-lock.json
+++ b/examples/minimal-react/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fishjam-dev/ts-client": "^0.5.0",
+        "@fishjam-dev/ts-client": "file:../ts-client-sdk",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0"
       },

--- a/examples/minimal-react/src/components/App.tsx
+++ b/examples/minimal-react/src/components/App.tsx
@@ -58,7 +58,7 @@ export const App = () => {
             // Get screen sharing MediaStream
             navigator.mediaDevices.getDisplayMedia(SCREEN_SHARING_MEDIA_CONSTRAINTS).then((screenStream) => {
               // Add local MediaStream to webrtc
-              screenStream.getTracks().forEach((track) => client.addTrack(track, screenStream, { type: "screen" }));
+              screenStream.getTracks().forEach((track) => client.addTrack(track, { type: "screen" }));
             });
           }}
         >

--- a/examples/use-camera-and-microphone-example/package-lock.json
+++ b/examples/use-camera-and-microphone-example/package-lock.json
@@ -33,7 +33,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk#mute-track",
+        "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0"
       },
@@ -49,7 +49,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
-        "prettier": "3.2.5",
+        "prettier": "3.3.2",
         "prettier-plugin-tailwindcss": "0.5.12",
         "react": "^18.2.0",
         "testcontainers": "^10.7.2",

--- a/examples/use-camera-and-microphone-example/package-lock.json
+++ b/examples/use-camera-and-microphone-example/package-lock.json
@@ -33,7 +33,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fishjam-dev/ts-client": "^0.5.0",
+        "@fishjam-dev/ts-client": "file:../ts-client-sdk",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0"
       },

--- a/examples/use-camera-and-microphone-example/package-lock.json
+++ b/examples/use-camera-and-microphone-example/package-lock.json
@@ -33,7 +33,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fishjam-dev/ts-client": "file:../ts-client-sdk",
+        "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk#mute-track",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0"
       },

--- a/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
+++ b/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
@@ -1,20 +1,21 @@
-import { PeerStatus, UseMicrophoneResult, UseCameraResult, UseScreenShareResult } from "@fishjam-dev/react-client";
+import { PeerStatus } from "@fishjam-dev/react-client";
 import { TrackMetadata } from "./fishjamSetup";
+import { CameraAPI, MicrophoneAPI, ScreenShareAPI } from "../../../src";
 
 type DeviceControlsProps = {
   status: PeerStatus;
   metadata: TrackMetadata;
 } & (
   | {
-      device: UseMicrophoneResult<TrackMetadata>;
+      device: MicrophoneAPI<TrackMetadata>;
       type: "audio";
     }
   | {
-      device: UseCameraResult<TrackMetadata>;
+      device: CameraAPI<TrackMetadata>;
       type: "video";
     }
   | {
-      device: UseScreenShareResult<TrackMetadata>;
+      device: ScreenShareAPI<TrackMetadata>;
       type: "screenshare";
     }
 );

--- a/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
+++ b/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
@@ -22,10 +22,6 @@ type DeviceControlsProps = {
 );
 
 export const DeviceControls = ({ device, type, status, metadata }: DeviceControlsProps) => {
-  useEffect(() => {
-    console.log({ device });
-  }, [device]);
-
   return (
     <div className="flex flex-col gap-2">
       <button

--- a/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
+++ b/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
@@ -1,6 +1,7 @@
 import { PeerStatus } from "@fishjam-dev/react-client";
 import { TrackMetadata } from "./fishjamSetup";
 import { CameraAPI, MicrophoneAPI, ScreenShareAPI } from "../../../src";
+import { useEffect } from "react";
 
 type DeviceControlsProps = {
   status: PeerStatus;
@@ -21,6 +22,10 @@ type DeviceControlsProps = {
 );
 
 export const DeviceControls = ({ device, type, status, metadata }: DeviceControlsProps) => {
+  useEffect(() => {
+    console.log({ device });
+  }, [device]);
+
   return (
     <div className="flex flex-col gap-2">
       <button

--- a/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
+++ b/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
@@ -1,7 +1,6 @@
 import { PeerStatus } from "@fishjam-dev/react-client";
 import { TrackMetadata } from "./fishjamSetup";
 import { CameraAPI, MicrophoneAPI, ScreenShareAPI } from "../../../src";
-import { useEffect } from "react";
 
 type DeviceControlsProps = {
   status: PeerStatus;

--- a/examples/use-camera-and-microphone-example/src/DeviceSelector.tsx
+++ b/examples/use-camera-and-microphone-example/src/DeviceSelector.tsx
@@ -4,11 +4,12 @@ type Props = {
   name: string;
   defaultOptionText: string;
   devices: MediaDeviceInfo[] | null;
+  stop: () => void;
   setInput: (value: string | null) => void;
   activeDevice: string | null;
 };
 
-export const DeviceSelector = ({ name, devices, setInput, defaultOptionText, activeDevice }: Props) => {
+export const DeviceSelector = ({ name, devices, setInput, defaultOptionText, activeDevice, stop }: Props) => {
   const [selectedDevice, setSelectedDevice] = useState<string | null>(null);
 
   const onOptionChangeHandler = (event: ChangeEvent<HTMLSelectElement>) => {
@@ -31,13 +32,22 @@ export const DeviceSelector = ({ name, devices, setInput, defaultOptionText, act
           ))}
         </select>
         <button
-          className="btn btn-error btn-sm"
+          className="btn btn-success btn-sm"
           disabled={!selectedDevice}
           onClick={() => {
             setInput(selectedDevice);
           }}
         >
-          Change device!
+          start / change
+        </button>
+        <button
+          className="btn btn-error btn-sm"
+          disabled={!selectedDevice}
+          onClick={() => {
+            stop()
+          }}
+        >
+          stop
         </button>
       </div>
     </div>

--- a/examples/use-camera-and-microphone-example/src/DeviceSelector.tsx
+++ b/examples/use-camera-and-microphone-example/src/DeviceSelector.tsx
@@ -44,7 +44,7 @@ export const DeviceSelector = ({ name, devices, setInput, defaultOptionText, act
           className="btn btn-error btn-sm"
           disabled={!selectedDevice}
           onClick={() => {
-            stop()
+            stop();
           }}
         >
           stop

--- a/examples/use-camera-and-microphone-example/src/MainControls.tsx
+++ b/examples/use-camera-and-microphone-example/src/MainControls.tsx
@@ -27,11 +27,11 @@ import { Badge } from "./Badge";
 import { DeviceControls } from "./DeviceControls";
 import { Radio } from "./Radio";
 
-type OnDeviceChange = "stop" | "replace" | undefined;
+type OnDeviceChange = "remove" | "replace" | undefined;
 type OnDeviceStop = "remove" | "mute" | undefined;
 
 const isDeviceChangeValue = (e: string | undefined): e is OnDeviceChange =>
-  e === undefined || e === "stop" || e === "replace";
+  e === undefined || e === "remove" || e === "replace";
 
 const isDeviceStopValue = (e: string | undefined): e is OnDeviceStop =>
   e === undefined || e === "remove" || e === "mute";
@@ -235,7 +235,7 @@ export const MainControls = () => {
             radioClass="radio-primary"
             options={[
               { value: undefined, key: "undefined" },
-              { value: "stop", key: "stop" },
+              { value: "remove", key: "remove" },
               { value: "replace", key: "replace" },
             ]}
           />
@@ -274,7 +274,7 @@ export const MainControls = () => {
             radioClass="radio-secondary"
             options={[
               { value: undefined, key: "undefined" },
-              { value: "stop", key: "stop" },
+              { value: "remove", key: "remove" },
               { value: "replace", key: "replace" },
             ]}
           />

--- a/examples/use-camera-and-microphone-example/src/MainControls.tsx
+++ b/examples/use-camera-and-microphone-example/src/MainControls.tsx
@@ -359,7 +359,7 @@ export const MainControls = () => {
 
           <div>
             <h3>Streaming:</h3>
-            <div className="max-w-[500px] flex flex-col gap-2">
+            <div className="flex max-w-[500px] flex-col gap-2">
               {local.map(({ trackId, stream, track }) => (
                 <div key={trackId} className="max-w-[500px] border">
                   <span>trackId: {trackId}</span>

--- a/examples/use-camera-and-microphone-example/src/MainControls.tsx
+++ b/examples/use-camera-and-microphone-example/src/MainControls.tsx
@@ -315,7 +315,7 @@ export const MainControls = () => {
           }}
           defaultOptionText="Select video device"
           stop={() => {
-            video.stop()
+            video.stop();
           }}
         />
 
@@ -329,7 +329,7 @@ export const MainControls = () => {
           }}
           defaultOptionText="Select audio device"
           stop={() => {
-            audio.stop()
+            audio.stop();
           }}
         />
 
@@ -359,12 +359,15 @@ export const MainControls = () => {
 
           <div>
             <h3>Streaming:</h3>
-            {local.map(({ trackId, stream, track }) => (
-              <div key={trackId} className="max-w-[500px]">
-                {track?.kind === "video" && <VideoPlayer key={trackId} stream={stream} />}
-                {track?.kind === "audio" && <AudioVisualizer trackId={track.id} stream={stream} />}
-              </div>
-            ))}
+            <div className="max-w-[500px] flex flex-col gap-2">
+              {local.map(({ trackId, stream, track }) => (
+                <div key={trackId} className="max-w-[500px] border">
+                  <span>trackId: {trackId}</span>
+                  {track?.kind === "audio" && <AudioVisualizer trackId={track.id} stream={stream} />}
+                  {track?.kind === "video" && <VideoPlayer key={trackId} stream={stream} />}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/examples/use-camera-and-microphone-example/src/MainControls.tsx
+++ b/examples/use-camera-and-microphone-example/src/MainControls.tsx
@@ -27,21 +27,26 @@ import { Badge } from "./Badge";
 import { DeviceControls } from "./DeviceControls";
 import { Radio } from "./Radio";
 
-type RestartChange = "stop" | "replace" | undefined;
+type OnDeviceChange = "stop" | "replace" | undefined;
+type OnDeviceStop = "remove" | "mute" | undefined;
 
-const isRestartChange = (e: string | undefined): e is RestartChange => {
-  return e === undefined || e === "stop" || e === "replace";
-};
+const isDeviceChangeValue = (e: string | undefined): e is OnDeviceChange =>
+  e === undefined || e === "stop" || e === "replace";
+
+const isDeviceStopValue = (e: string | undefined): e is OnDeviceStop =>
+  e === undefined || e === "remove" || e === "mute";
 
 const tokenAtom = atomWithStorage("token", "");
 
 const broadcastVideoOnConnectAtom = atomWithStorage<boolean | undefined>("broadcastVideoOnConnect", undefined);
 const broadcastVideoOnDeviceStartAtom = atomWithStorage<boolean | undefined>("broadcastVideoOnDeviceStart", undefined);
-const broadcastVideoOnDeviceChangeAtom = atomWithStorage<RestartChange>("broadcastVideoOnDeviceChange", undefined);
+const videoOnDeviceChangeAtom = atomWithStorage<OnDeviceChange>("videoOnDeviceChange", undefined);
+const videoOnDeviceStopAtom = atomWithStorage<OnDeviceStop>("videoOnDeviceStop", undefined);
 
 const broadcastAudioOnConnectAtom = atomWithStorage<boolean | undefined>("broadcastAudioOnConnect", undefined);
 const broadcastAudioOnDeviceStartAtom = atomWithStorage<boolean | undefined>("broadcastAudioOnDeviceStart", undefined);
-const broadcastAudioOnDeviceChangeAtom = atomWithStorage<RestartChange>("broadcastAudioOnDeviceChange", undefined);
+const audioOnDeviceChangeAtom = atomWithStorage<OnDeviceChange>("audioOnDeviceChange", undefined);
+const audioOnDeviceStopAtom = atomWithStorage<OnDeviceStop>("audioOnDeviceStop", undefined);
 
 const broadcastScreenShareOnConnectAtom = atomWithStorage<boolean | undefined>(
   "broadcastScreenShareOnConnect",
@@ -67,11 +72,13 @@ export const MainControls = () => {
 
   const [broadcastVideoOnConnect, setBroadcastVideoOnConnect] = useAtom(broadcastVideoOnConnectAtom);
   const [broadcastVideoOnDeviceStart, setBroadcastVideoOnDeviceStart] = useAtom(broadcastVideoOnDeviceStartAtom);
-  const [broadcastVideoOnDeviceChange, setBroadcastVideoOnDeviceChange] = useAtom(broadcastVideoOnDeviceChangeAtom);
+  const [broadcastVideoOnDeviceChange, setBroadcastVideoOnDeviceChange] = useAtom(videoOnDeviceChangeAtom);
+  const [broadcastVideoOnDeviceStop, setBroadcastVideoOnDeviceStop] = useAtom(videoOnDeviceStopAtom);
 
   const [broadcastAudioOnConnect, setBroadcastAudioOnConnect] = useAtom(broadcastAudioOnConnectAtom);
   const [broadcastAudioOnDeviceStart, setBroadcastAudioOnDeviceStart] = useAtom(broadcastAudioOnDeviceStartAtom);
-  const [broadcastAudioOnDeviceChange, setBroadcastAudioOnDeviceChange] = useAtom(broadcastAudioOnDeviceChangeAtom);
+  const [broadcastAudioOnDeviceChange, setBroadcastAudioOnDeviceChange] = useAtom(audioOnDeviceChangeAtom);
+  const [broadcastAudioOnDeviceStop, setBroadcastAudioOnDeviceStop] = useAtom(audioOnDeviceStopAtom);
 
   const [broadcastScreenShareOnConnect, setBroadcastScreenShareOnConnect] = useAtom(broadcastScreenShareOnConnectAtom);
   const [broadcastScreenShareOnDeviceStart, setBroadcastScreenShareOnDeviceStart] = useAtom(
@@ -85,7 +92,8 @@ export const MainControls = () => {
       trackConstraints: VIDEO_TRACK_CONSTRAINTS,
       broadcastOnConnect: broadcastVideoOnConnect,
       broadcastOnDeviceStart: broadcastVideoOnDeviceStart,
-      broadcastOnDeviceChange: broadcastVideoOnDeviceChange,
+      onDeviceChange: broadcastVideoOnDeviceChange,
+      onDeviceStop: broadcastVideoOnDeviceStop,
       defaultTrackMetadata: DEFAULT_VIDEO_TRACK_METADATA,
       defaultSimulcastConfig: {
         enabled: true,
@@ -97,7 +105,8 @@ export const MainControls = () => {
       trackConstraints: AUDIO_TRACK_CONSTRAINTS,
       broadcastOnConnect: broadcastAudioOnConnect,
       broadcastOnDeviceStart: broadcastAudioOnDeviceStart,
-      broadcastOnDeviceChange: broadcastAudioOnDeviceChange,
+      onDeviceChange: broadcastAudioOnDeviceChange,
+      onDeviceStop: broadcastAudioOnDeviceStop,
       defaultTrackMetadata: DEFAULT_AUDIO_TRACK_METADATA,
     },
     screenShare: {
@@ -221,13 +230,26 @@ export const MainControls = () => {
             name='Broadcast video on device change (default "replace")'
             value={broadcastVideoOnDeviceChange}
             set={(value) => {
-              if (isRestartChange(value)) setBroadcastVideoOnDeviceChange(value);
+              if (isDeviceChangeValue(value)) setBroadcastVideoOnDeviceChange(value);
             }}
             radioClass="radio-primary"
             options={[
               { value: undefined, key: "undefined" },
               { value: "stop", key: "stop" },
               { value: "replace", key: "replace" },
+            ]}
+          />
+          <Radio
+            name='Broadcast video on device stop (default "mute")'
+            value={broadcastVideoOnDeviceStop}
+            set={(value) => {
+              if (isDeviceStopValue(value)) setBroadcastVideoOnDeviceStop(value);
+            }}
+            radioClass="radio-primary"
+            options={[
+              { value: undefined, key: "undefined" },
+              { value: "remove", key: "remove" },
+              { value: "mute", key: "mute" },
             ]}
           />
 
@@ -247,13 +269,26 @@ export const MainControls = () => {
             name='Broadcast audio on device change (default "replace")'
             value={broadcastAudioOnDeviceChange}
             set={(value) => {
-              if (isRestartChange(value)) setBroadcastAudioOnDeviceChange(value);
+              if (isDeviceChangeValue(value)) setBroadcastAudioOnDeviceChange(value);
             }}
             radioClass="radio-secondary"
             options={[
               { value: undefined, key: "undefined" },
               { value: "stop", key: "stop" },
               { value: "replace", key: "replace" },
+            ]}
+          />
+          <Radio
+            name='Broadcast audio on device stop (default "mute")'
+            value={broadcastAudioOnDeviceStop}
+            set={(value) => {
+              if (isDeviceStopValue(value)) setBroadcastAudioOnDeviceStop(value);
+            }}
+            radioClass="radio-secondary"
+            options={[
+              { value: undefined, key: "undefined" },
+              { value: "remove", key: "remove" },
+              { value: "mute", key: "mute" },
             ]}
           />
 
@@ -279,6 +314,9 @@ export const MainControls = () => {
             video.start(id);
           }}
           defaultOptionText="Select video device"
+          stop={() => {
+            video.stop()
+          }}
         />
 
         <DeviceSelector
@@ -290,6 +328,9 @@ export const MainControls = () => {
             audio.start(id);
           }}
           defaultOptionText="Select audio device"
+          stop={() => {
+            audio.stop()
+          }}
         />
 
         <div className="grid grid-cols-3 gap-2">

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
     },
     "node_modules/@fishjam-dev/ts-client": {
       "version": "0.5.0",
-      "resolved": "git+ssh://git@github.com/fishjam-dev/ts-client-sdk.git#08e7927500b11de2293b5a4ffe574112ae38b12b",
+      "resolved": "git+ssh://git@github.com/fishjam-dev/ts-client-sdk.git#8c5a0971ee625e209f6b3910782055eeadda5f83",
       "dependencies": {
         "events": "^3.3.0",
         "protobufjs": "^7.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fishjam-dev/ts-client": "file:../ts-client-sdk",
+        "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk#mute-track",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0"
       },
@@ -38,10 +38,11 @@
     "../ts-client-sdk": {
       "name": "@fishjam-dev/ts-client",
       "version": "0.5.0",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "events": "^3.3.0",
-        "ts-proto": "^1.165.0",
+        "protobufjs": "^7.3.0",
         "typed-emitter": "^2.1.0",
         "uuid": "^9.0.1"
       },
@@ -57,15 +58,18 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "fake-mediastreamtrack": "^1.2.0",
+        "husky": "^9.0.11",
+        "lint-staged": "^15.2.5",
         "prettier": "^3.1.0",
         "prettier-plugin-tailwindcss": "^0.5.7",
         "react": "^18.2.0",
         "testcontainers": "^10.3.2",
+        "ts-proto": "^1.176.0",
         "typed-emitter": "^2.1.0",
         "typedoc": "^0.25.13",
         "typedoc-plugin-external-resolver": "^1.0.3",
         "typedoc-plugin-mdn-links": "^3.1.6",
-        "typescript": "^4.9.5",
+        "typescript": "^5.4.5",
         "vitest": "^1.6.0",
         "zod": "^3.23.6"
       }
@@ -142,8 +146,14 @@
       }
     },
     "node_modules/@fishjam-dev/ts-client": {
-      "resolved": "../ts-client-sdk",
-      "link": true
+      "version": "0.5.0",
+      "resolved": "git+ssh://git@github.com/fishjam-dev/ts-client-sdk.git#08e7927500b11de2293b5a4ffe574112ae38b12b",
+      "dependencies": {
+        "events": "^3.3.0",
+        "protobufjs": "^7.3.0",
+        "typed-emitter": "^2.1.0",
+        "uuid": "^9.0.1"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -228,6 +238,60 @@
         "node": ">=16"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@types/docker-modem": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
@@ -279,7 +343,6 @@
       "version": "20.11.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
       "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2069,6 +2132,11 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2487,6 +2555,29 @@
         "url": "https://github.com/steveukx/properties?sponsor=1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2658,7 +2749,6 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -2668,7 +2758,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-      "dev": true,
       "optional": true
     },
     "node_modules/safe-buffer": {
@@ -2998,7 +3087,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "dev": true,
       "optionalDependencies": {
         "rxjs": "*"
       }
@@ -3073,8 +3161,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3090,6 +3177,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fishjam-dev/ts-client": "file:../ts-client-sdk",
+        "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk#mute-track",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0"
       },
@@ -33,41 +33,6 @@
         "typedoc": "^0.25.12",
         "typedoc-plugin-mdn-links": "^3.1.18",
         "typescript": "5.4.2"
-      }
-    },
-    "../ts-client-sdk": {
-      "name": "@fishjam-dev/ts-client",
-      "version": "0.5.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "events": "^3.3.0",
-        "ts-proto": "^1.165.0",
-        "typed-emitter": "^2.1.0",
-        "uuid": "^9.0.1"
-      },
-      "devDependencies": {
-        "@playwright/test": "^1.40.1",
-        "@types/events": "^3.0.3",
-        "@types/node": "^20.10.3",
-        "@types/uuid": "^9.0.8",
-        "@typescript-eslint/eslint-plugin": "^7.8.0",
-        "@typescript-eslint/parser": "^7.8.0",
-        "@vitest/coverage-v8": "^1.6.0",
-        "eslint": "^8.55.0",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-react-hooks": "^4.6.0",
-        "fake-mediastreamtrack": "^1.2.0",
-        "prettier": "^3.1.0",
-        "prettier-plugin-tailwindcss": "^0.5.7",
-        "react": "^18.2.0",
-        "testcontainers": "^10.3.2",
-        "typed-emitter": "^2.1.0",
-        "typedoc": "^0.25.13",
-        "typedoc-plugin-external-resolver": "^1.0.3",
-        "typedoc-plugin-mdn-links": "^3.1.6",
-        "typescript": "^4.9.5",
-        "vitest": "^1.6.0",
-        "zod": "^3.23.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -142,8 +107,14 @@
       }
     },
     "node_modules/@fishjam-dev/ts-client": {
-      "resolved": "../ts-client-sdk",
-      "link": true
+      "version": "0.5.0",
+      "resolved": "git+ssh://git@github.com/fishjam-dev/ts-client-sdk.git#32eb40297c7a583a55b4dfbcd17faf2943dabf09",
+      "dependencies": {
+        "events": "^3.3.0",
+        "ts-proto": "^1.165.0",
+        "typed-emitter": "^2.1.0",
+        "uuid": "^9.0.1"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -228,6 +199,60 @@
         "node": ">=16"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@types/docker-modem": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
@@ -279,7 +304,6 @@
       "version": "20.11.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
       "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1124,6 +1148,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1274,6 +1309,17 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1349,6 +1395,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dprint-node": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.8.tgz",
+      "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
       }
     },
     "node_modules/end-of-stream": {
@@ -2069,6 +2123,11 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2487,6 +2546,29 @@
         "url": "https://github.com/steveukx/properties?sponsor=1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2658,7 +2740,6 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -2668,7 +2749,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-      "dev": true,
       "optional": true
     },
     "node_modules/safe-buffer": {
@@ -2964,6 +3044,37 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-poet": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.9.0.tgz",
+      "integrity": "sha512-roe6W6MeZmCjRmppyfOURklO5tQFQ6Sg7swURKkwYJvV7dbGCrK28um5+51iW3twdPRKtwarqFAVMU6G1mvnuQ==",
+      "dependencies": {
+        "dprint-node": "^1.0.8"
+      }
+    },
+    "node_modules/ts-proto": {
+      "version": "1.176.1",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.176.1.tgz",
+      "integrity": "sha512-oZtvXcAe/4ILiHSvNhrQAqZ3MHpwHXZ+J0gN1rBLvTQ7NBAmM8Ccl2kTiUqybDBs/48FFEalAqtErcjvO6ePPQ==",
+      "dependencies": {
+        "case-anything": "^2.1.13",
+        "protobufjs": "^7.2.4",
+        "ts-poet": "^6.7.0",
+        "ts-proto-descriptors": "1.16.0"
+      },
+      "bin": {
+        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
+      }
+    },
+    "node_modules/ts-proto-descriptors": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.16.0.tgz",
+      "integrity": "sha512-3yKuzMLpltdpcyQji1PJZRfoo4OJjNieKTYkQY8pF7xGKsYz/RHe3aEe4KiRxcinoBmnEhmuI+yJTxLb922ULA==",
+      "dependencies": {
+        "long": "^5.2.3",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -2998,7 +3109,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "dev": true,
       "optionalDependencies": {
         "rxjs": "*"
       }
@@ -3073,8 +3183,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3090,6 +3199,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@jellyfish-dev/react-client-sdk",
+  "name": "@fishjam-dev/react-client",
   "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@jellyfish-dev/react-client-sdk",
+      "name": "@fishjam-dev/react-client",
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fishjam-dev/ts-client": "^0.5.0",
+        "@fishjam-dev/ts-client": "file:../ts-client-sdk",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0"
       },
@@ -36,9 +36,8 @@
       }
     },
     "../ts-client-sdk": {
-      "name": "@jellyfish-dev/ts-client-sdk",
-      "version": "0.4.0",
-      "extraneous": true,
+      "name": "@fishjam-dev/ts-client",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "events": "^3.3.0",
@@ -143,15 +142,8 @@
       }
     },
     "node_modules/@fishjam-dev/ts-client": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@fishjam-dev/ts-client/-/ts-client-0.5.0.tgz",
-      "integrity": "sha512-Hbcm0hcjovj8zEu9R6A5uFAVpZNLrO/ycV6W+wQyzIkJn6/sUgunqdqyRHYgsnNz2WMM1J4SI0P5tonMAvTViQ==",
-      "dependencies": {
-        "events": "^3.3.0",
-        "ts-proto": "^1.165.0",
-        "typed-emitter": "^2.1.0",
-        "uuid": "^9.0.1"
-      }
+      "resolved": "../ts-client-sdk",
+      "link": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -236,60 +228,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
     "node_modules/@types/docker-modem": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
@@ -341,6 +279,7 @@
       "version": "20.11.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
       "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1185,17 +1124,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1346,17 +1274,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1432,14 +1349,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dprint-node": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.8.tgz",
-      "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
-      "dependencies": {
-        "detect-libc": "^1.0.3"
       }
     },
     "node_modules/end-of-stream": {
@@ -2160,11 +2069,6 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
-    "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2583,29 +2487,6 @@
         "url": "https://github.com/steveukx/properties?sponsor=1"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
-      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2777,6 +2658,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -2786,6 +2668,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "dev": true,
       "optional": true
     },
     "node_modules/safe-buffer": {
@@ -3081,37 +2964,6 @@
         "typescript": ">=4.2.0"
       }
     },
-    "node_modules/ts-poet": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.9.0.tgz",
-      "integrity": "sha512-roe6W6MeZmCjRmppyfOURklO5tQFQ6Sg7swURKkwYJvV7dbGCrK28um5+51iW3twdPRKtwarqFAVMU6G1mvnuQ==",
-      "dependencies": {
-        "dprint-node": "^1.0.8"
-      }
-    },
-    "node_modules/ts-proto": {
-      "version": "1.176.0",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.176.0.tgz",
-      "integrity": "sha512-OWVrVUpNfZVfvKJZlSjRmCPkcNcox6IPRw3RIeyK2Z4d0Uoy1/gkumMwCVOAMznZcv80D1r9GyYHgYVdp6Cj+g==",
-      "dependencies": {
-        "case-anything": "^2.1.13",
-        "protobufjs": "^7.2.4",
-        "ts-poet": "^6.7.0",
-        "ts-proto-descriptors": "1.16.0"
-      },
-      "bin": {
-        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
-      }
-    },
-    "node_modules/ts-proto-descriptors": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.16.0.tgz",
-      "integrity": "sha512-3yKuzMLpltdpcyQji1PJZRfoo4OJjNieKTYkQY8pF7xGKsYz/RHe3aEe4KiRxcinoBmnEhmuI+yJTxLb922ULA==",
-      "dependencies": {
-        "long": "^5.2.3",
-        "protobufjs": "^7.2.4"
-      }
-    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -3146,6 +2998,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "dev": true,
       "optionalDependencies": {
         "rxjs": "*"
       }
@@ -3220,7 +3073,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3236,18 +3090,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk#mute-track",
+        "@fishjam-dev/ts-client": "file:../ts-client-sdk",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0"
       },
@@ -33,6 +33,41 @@
         "typedoc": "^0.25.12",
         "typedoc-plugin-mdn-links": "^3.1.18",
         "typescript": "5.4.2"
+      }
+    },
+    "../ts-client-sdk": {
+      "name": "@fishjam-dev/ts-client",
+      "version": "0.5.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "events": "^3.3.0",
+        "ts-proto": "^1.165.0",
+        "typed-emitter": "^2.1.0",
+        "uuid": "^9.0.1"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.40.1",
+        "@types/events": "^3.0.3",
+        "@types/node": "^20.10.3",
+        "@types/uuid": "^9.0.8",
+        "@typescript-eslint/eslint-plugin": "^7.8.0",
+        "@typescript-eslint/parser": "^7.8.0",
+        "@vitest/coverage-v8": "^1.6.0",
+        "eslint": "^8.55.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "fake-mediastreamtrack": "^1.2.0",
+        "prettier": "^3.1.0",
+        "prettier-plugin-tailwindcss": "^0.5.7",
+        "react": "^18.2.0",
+        "testcontainers": "^10.3.2",
+        "typed-emitter": "^2.1.0",
+        "typedoc": "^0.25.13",
+        "typedoc-plugin-external-resolver": "^1.0.3",
+        "typedoc-plugin-mdn-links": "^3.1.6",
+        "typescript": "^4.9.5",
+        "vitest": "^1.6.0",
+        "zod": "^3.23.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -107,14 +142,8 @@
       }
     },
     "node_modules/@fishjam-dev/ts-client": {
-      "version": "0.5.0",
-      "resolved": "git+ssh://git@github.com/fishjam-dev/ts-client-sdk.git#32eb40297c7a583a55b4dfbcd17faf2943dabf09",
-      "dependencies": {
-        "events": "^3.3.0",
-        "ts-proto": "^1.165.0",
-        "typed-emitter": "^2.1.0",
-        "uuid": "^9.0.1"
-      }
+      "resolved": "../ts-client-sdk",
+      "link": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -199,60 +228,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
     "node_modules/@types/docker-modem": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
@@ -304,6 +279,7 @@
       "version": "20.11.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
       "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1148,17 +1124,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1309,17 +1274,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1395,14 +1349,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dprint-node": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.8.tgz",
-      "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
-      "dependencies": {
-        "detect-libc": "^1.0.3"
       }
     },
     "node_modules/end-of-stream": {
@@ -2123,11 +2069,6 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
-    "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2546,29 +2487,6 @@
         "url": "https://github.com/steveukx/properties?sponsor=1"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
-      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2740,6 +2658,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -2749,6 +2668,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "dev": true,
       "optional": true
     },
     "node_modules/safe-buffer": {
@@ -3044,37 +2964,6 @@
         "typescript": ">=4.2.0"
       }
     },
-    "node_modules/ts-poet": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.9.0.tgz",
-      "integrity": "sha512-roe6W6MeZmCjRmppyfOURklO5tQFQ6Sg7swURKkwYJvV7dbGCrK28um5+51iW3twdPRKtwarqFAVMU6G1mvnuQ==",
-      "dependencies": {
-        "dprint-node": "^1.0.8"
-      }
-    },
-    "node_modules/ts-proto": {
-      "version": "1.176.1",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.176.1.tgz",
-      "integrity": "sha512-oZtvXcAe/4ILiHSvNhrQAqZ3MHpwHXZ+J0gN1rBLvTQ7NBAmM8Ccl2kTiUqybDBs/48FFEalAqtErcjvO6ePPQ==",
-      "dependencies": {
-        "case-anything": "^2.1.13",
-        "protobufjs": "^7.2.4",
-        "ts-poet": "^6.7.0",
-        "ts-proto-descriptors": "1.16.0"
-      },
-      "bin": {
-        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
-      }
-    },
-    "node_modules/ts-proto-descriptors": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.16.0.tgz",
-      "integrity": "sha512-3yKuzMLpltdpcyQji1PJZRfoo4OJjNieKTYkQY8pF7xGKsYz/RHe3aEe4KiRxcinoBmnEhmuI+yJTxLb922ULA==",
-      "dependencies": {
-        "long": "^5.2.3",
-        "protobufjs": "^7.2.4"
-      }
-    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -3109,6 +2998,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "dev": true,
       "optionalDependencies": {
         "rxjs": "*"
       }
@@ -3183,7 +3073,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3199,18 +3090,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk#mute-track",
+        "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0"
       },
@@ -147,7 +147,7 @@
     },
     "node_modules/@fishjam-dev/ts-client": {
       "version": "0.5.0",
-      "resolved": "git+ssh://git@github.com/fishjam-dev/ts-client-sdk.git#8c5a0971ee625e209f6b3910782055eeadda5f83",
+      "resolved": "git+ssh://git@github.com/fishjam-dev/ts-client-sdk.git#d254b040a184b9631c64e36bb80a453e0757005c",
       "dependencies": {
         "events": "^3.3.0",
         "protobufjs": "^7.3.0",
@@ -2556,9 +2556,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
-      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "5.4.2"
   },
   "dependencies": {
-    "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk#mute-track",
+    "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk",
     "events": "3.3.0",
     "lodash.isequal": "4.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "5.4.2"
   },
   "dependencies": {
-    "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk#mute-track",
+    "@fishjam-dev/ts-client": "file:../ts-client-sdk",
     "events": "3.3.0",
     "lodash.isequal": "4.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "5.4.2"
   },
   "dependencies": {
-    "@fishjam-dev/ts-client": "file:../ts-client-sdk",
+    "@fishjam-dev/ts-client": "github:fishjam-dev/ts-client-sdk#mute-track",
     "events": "3.3.0",
     "lodash.isequal": "4.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "5.4.2"
   },
   "dependencies": {
-    "@fishjam-dev/ts-client": "^0.5.0",
+    "@fishjam-dev/ts-client": "file:../ts-client-sdk",
     "events": "3.3.0",
     "lodash.isequal": "4.5.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ export const App = () => {
           onClick={() => {
             // Get screen sharing MediaStream
             navigator.mediaDevices.getDisplayMedia(SCREEN_SHARING_MEDIA_CONSTRAINTS).then((screenStream) => {
-              // Add local MediaStream to webrtcx 
+              // Add local MediaStream to webrtcx
               screenStream.getTracks().forEach((track) => api.addTrack(track, { type: "screen" }));
             });
           }}

--- a/readme.md
+++ b/readme.md
@@ -111,8 +111,8 @@ export const App = () => {
           onClick={() => {
             // Get screen sharing MediaStream
             navigator.mediaDevices.getDisplayMedia(SCREEN_SHARING_MEDIA_CONSTRAINTS).then((screenStream) => {
-              // Add local MediaStream to webrtc
-              screenStream.getTracks().forEach((track) => api.addTrack(track, screenStream, { type: "screen" }));
+              // Add local MediaStream to webrtcx 
+              screenStream.getTracks().forEach((track) => api.addTrack(track, { type: "screen" }));
             });
           }}
         >

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ export const App = () => {
           onClick={() => {
             // Get screen sharing MediaStream
             navigator.mediaDevices.getDisplayMedia(SCREEN_SHARING_MEDIA_CONSTRAINTS).then((screenStream) => {
-              // Add local MediaStream to webrtcx
+              // Add local MediaStream to webrtc
               screenStream.getTracks().forEach((track) => api.addTrack(track, { type: "screen" }));
             });
           }}

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -20,9 +20,9 @@ import { MediaDeviceType, ScreenShareManager, ScreenShareManagerConfig } from ".
 import {
   DeviceManagerConfig,
   DeviceState,
-  InitMediaConfig,
-  UseCameraAndMicrophoneResult,
-  UseUserMediaState,
+  DeviceManagerInitConfig,
+  Devices,
+  MediaState,
 } from "./types";
 
 export type ClientApi<PeerMetadata, TrackMetadata> = {
@@ -36,8 +36,8 @@ export type ClientApi<PeerMetadata, TrackMetadata> = {
 
   bandwidthEstimation: bigint;
   status: PeerStatus;
-  media: UseUserMediaState | null;
-  devices: UseCameraAndMicrophoneResult<TrackMetadata>;
+  media: MediaState | null;
+  devices: Devices<TrackMetadata>;
   deviceManager: DeviceManager;
   screenShareManager: ScreenShareManager;
 };
@@ -302,8 +302,8 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
 
   public bandwidthEstimation: bigint = BigInt(0);
   public status: PeerStatus = null;
-  public media: UseUserMediaState | null = null;
-  public devices: UseCameraAndMicrophoneResult<TrackMetadata>;
+  public media: MediaState | null = null;
+  public devices: Devices<TrackMetadata>;
 
   private currentMicrophoneTrackId: string | null = null;
   private currentCameraTrackId: string | null = null;
@@ -776,8 +776,8 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
       (track) => track.track?.id === this.currentScreenShareTrackId,
     );
 
-    const devices: UseCameraAndMicrophoneResult<TrackMetadata> = {
-      init: (config?: InitMediaConfig) => {
+    const devices: Devices<TrackMetadata> = {
+      init: (config?: DeviceManagerInitConfig) => {
         this?.deviceManager?.init(config);
       },
       start: (config) => this?.deviceManager?.start(config),

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -19,10 +19,7 @@ import type { DeviceManagerEvents } from "./DeviceManager";
 import { DeviceManager } from "./DeviceManager";
 import type { MediaDeviceType, ScreenShareManagerConfig } from "./ScreenShareManager";
 import { ScreenShareManager } from "./ScreenShareManager";
-import type {
-  DeviceManagerConfig, DeviceManagerInitConfig, Devices,
-  DeviceState, MediaState
-} from "./types";
+import type { DeviceManagerConfig, DeviceManagerInitConfig, Devices, DeviceState, MediaState } from "./types";
 
 export type ClientApi<PeerMetadata, TrackMetadata> = {
   local: PeerState<PeerMetadata, TrackMetadata> | null;

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -858,7 +858,7 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
           return this.tsClient.removeTrack(prevTrack.trackId);
         },
         replaceTrack: async (newTrackMetadata?: TrackMetadata) => {
-          if (!this.currentCameraTrackId) throw Error("There is no audio track id");
+          if (!this.currentCameraTrackId) throw Error("There is no  track id");
 
           const prevTrack = this.getRemoteTrack(this.currentCameraTrackId);
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -813,8 +813,6 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
     const broadcastedAudioTrack = this.getRemoteTrack(this.currentMicrophoneTrackId);
     const screenShareVideoTrack = this.getRemoteTrack(this.currentScreenShareTrackId);
 
-    console.log({ broadcastedVideoTrack });
-
     const devices: Devices<TrackMetadata> = {
       init: (config?: DeviceManagerInitConfig) => {
         this?.deviceManager?.init(config);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -813,6 +813,8 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
     const broadcastedAudioTrack = this.getRemoteTrack(this.currentMicrophoneTrackId);
     const screenShareVideoTrack = this.getRemoteTrack(this.currentScreenShareTrackId);
 
+    console.log({ broadcastedVideoTrack });
+
     const devices: Devices<TrackMetadata> = {
       init: (config?: DeviceManagerInitConfig) => {
         this?.deviceManager?.init(config);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -695,14 +695,13 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
 
   public addTrack(
     track: MediaStreamTrack,
-    stream: MediaStream,
     trackMetadata?: TrackMetadata,
     simulcastConfig: SimulcastConfig = { enabled: false, activeEncodings: [], disabledEncodings: [] },
     maxBandwidth: TrackBandwidthLimit = 0, // unlimited bandwidth
   ): Promise<string> {
     if (!this.tsClient) throw Error("Client not initialized");
 
-    return this.tsClient.addTrack(track, stream, trackMetadata, simulcastConfig, maxBandwidth);
+    return this.tsClient.addTrack(track, trackMetadata, simulcastConfig, maxBandwidth);
   }
 
   public removeTrack(trackId: string): Promise<void> {
@@ -806,10 +805,7 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
 
           this.currentCameraTrackId = track?.id;
 
-          const stream = new MediaStream();
-          stream.addTrack(track);
-
-          return this.tsClient.addTrack(track, stream, trackMetadata, simulcastConfig, maxBandwidth);
+          return this.tsClient.addTrack(track, trackMetadata, simulcastConfig, maxBandwidth);
         },
         removeTrack: () => {
           const prevTrack = Object.values(localTracks).find((track) => track.track?.id === this.currentCameraTrackId);
@@ -830,15 +826,6 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
           if (!track) throw Error("New track is empty");
 
           this.currentCameraTrackId = track.id;
-
-          // todo This is a temporary solution to address an issue with ts-client
-          //  Currently, ts-client does not update the track in the stream during the execution of the replaceTrack method
-          if (!this.devices.camera.broadcast?.stream) throw Error("New stream is empty");
-
-          this.devices.camera.broadcast?.stream?.removeTrack(
-            this.devices.camera.broadcast?.stream?.getVideoTracks()[0],
-          );
-          this.devices.camera.broadcast?.stream.addTrack(track);
 
           await this.tsClient.replaceTrack(prevTrack.trackId, track, newTrackMetadata);
         },
@@ -872,10 +859,7 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
 
           this.currentMicrophoneTrackId = track.id;
 
-          const stream = new MediaStream();
-          stream.addTrack(track);
-
-          return this.tsClient.addTrack(track, stream, trackMetadata, undefined, maxBandwidth);
+          return this.tsClient.addTrack(track, trackMetadata, undefined, maxBandwidth);
         },
         removeTrack: () => {
           const prevTrack = Object.values(localTracks).find(
@@ -900,16 +884,6 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
           if (!track) throw Error("New track is empty");
 
           this.currentMicrophoneTrackId = track.id;
-
-          // todo This is a temporary solution to address an issue with ts-client
-          //  Currently, ts-client does not update the track in the stream during the execution of the replaceTrack method
-          if (!this.devices.microphone.broadcast?.stream) throw Error("New stream is empty");
-
-          this.devices.microphone.broadcast?.stream?.removeTrack(
-            this.devices.microphone.broadcast?.stream?.getAudioTracks()[0],
-          );
-
-          this.devices.microphone.broadcast?.stream.addTrack(track);
 
           await this.tsClient.replaceTrack(prevTrack.trackId, track, newTrackMetadata);
         },
@@ -946,7 +920,7 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
 
           this.currentScreenShareTrackId = track?.id;
 
-          return this.tsClient.addTrack(track, stream, trackMetadata, undefined, maxBandwidth);
+          return this.tsClient.addTrack(track, trackMetadata, undefined, maxBandwidth);
         },
         removeTrack: () => {
           const prevTrack = Object.values(localTracks).find(

--- a/src/DeviceManager.ts
+++ b/src/DeviceManager.ts
@@ -9,7 +9,8 @@ import type {
   GetMedia,
   DeviceManagerInitConfig,
   Media,
-  StorageConfig, DeviceManagerStartConfig
+  StorageConfig,
+  DeviceManagerStartConfig,
 } from "./types";
 import { NOT_FOUND_ERROR, OVERCONSTRAINED_ERROR, parseError, PERMISSION_DENIED, UNHANDLED_ERROR } from "./types";
 

--- a/src/DeviceManager.ts
+++ b/src/DeviceManager.ts
@@ -7,7 +7,7 @@ import {
   DeviceState,
   Errors,
   GetMedia,
-  InitMediaConfig,
+  DeviceManagerInitConfig,
   Media,
   NOT_FOUND_ERROR,
   OVERCONSTRAINED_ERROR,
@@ -15,7 +15,7 @@ import {
   PERMISSION_DENIED,
   StorageConfig,
   UNHANDLED_ERROR,
-  UseUserMediaStartConfig,
+  DeviceManagerStartConfig,
 } from "./types";
 
 import { loadObject, saveObject } from "./localStorage";
@@ -340,7 +340,7 @@ export class DeviceManager extends (EventEmitter as new () => TypedEmitter<Devic
     return this.status;
   }
 
-  public async init(config?: InitMediaConfig): Promise<"initialized" | "error"> {
+  public async init(config?: DeviceManagerInitConfig): Promise<"initialized" | "error"> {
     if (this.status !== "uninitialized") {
       return Promise.reject("Device manager already initialized");
     }
@@ -512,7 +512,7 @@ export class DeviceManager extends (EventEmitter as new () => TypedEmitter<Devic
   }
 
   // todo `audioDeviceId / videoDeviceId === true` means use last device
-  public async start({ audioDeviceId, videoDeviceId }: UseUserMediaStartConfig) {
+  public async start({ audioDeviceId, videoDeviceId }: DeviceManagerStartConfig) {
     const shouldRestartVideo = !!videoDeviceId && videoDeviceId !== this.video.media?.deviceInfo?.deviceId;
     const shouldRestartAudio = !!audioDeviceId && audioDeviceId !== this.audio.media?.deviceInfo?.deviceId;
 

--- a/src/create.tsx
+++ b/src/create.tsx
@@ -493,13 +493,13 @@ export const create = <PeerMetadata, TrackMetadata>(
         ) {
           const onDeviceStop = configRef.current.microphone.onDeviceStop ?? "mute";
 
-          if(onDeviceStop === "mute") {
+          if (onDeviceStop === "mute") {
             console.log({ name: "removeOnMicrophoneStopped-replaceTrack" });
 
-            await client.devices.microphone.muteTrack()
+            await client.devices.microphone.muteTrack();
           } else {
             console.log({ name: "removeOnMicrophoneStopped-removeTrack" });
-            await client.devices.microphone.removeTrack()
+            await client.devices.microphone.removeTrack();
           }
         }
       };

--- a/src/create.tsx
+++ b/src/create.tsx
@@ -174,6 +174,9 @@ export const create = <PeerMetadata, TrackMetadata>(
         client.removeListener("localTrackAdded", callback);
         client.removeListener("localTrackRemoved", callback);
         client.removeListener("localTrackReplaced", callback);
+        client.removeListener("localTrackMuted", callback);
+        client.removeListener("localTrackUnmuted", callback);
+
         client.removeListener("localTrackBandwidthSet", callback);
         client.removeListener("localTrackEncodingBandwidthSet", callback);
         client.removeListener("localTrackEncodingEnabled", callback);
@@ -300,8 +303,6 @@ export const create = <PeerMetadata, TrackMetadata>(
 
         if (client.status === "joined" && event.mediaDeviceType === "userMedia" && !pending) {
           if (!client.devices.camera.broadcast?.stream && configRef.current.camera.broadcastOnDeviceStart) {
-            console.log({ name: "broadcastOnCameraStart-addTrack" });
-
             pending = true;
 
             await client.devices.camera
@@ -314,16 +315,12 @@ export const create = <PeerMetadata, TrackMetadata>(
                 pending = false;
               });
           } else if (client.devices.camera.broadcast?.stream && broadcastOnDeviceChange === "replace") {
-            console.log({ name: "broadcastOnCameraStart-replaceTrack" });
-
             pending = true;
 
             await client.devices.camera.replaceTrack().finally(() => {
               pending = false;
             });
           } else if (client.devices.camera.broadcast?.stream && broadcastOnDeviceChange === "stop") {
-            console.log({ name: "broadcastOnCameraStart-stop" });
-
             pending = true;
 
             await client.devices.camera.removeTrack().finally(() => {
@@ -422,8 +419,6 @@ export const create = <PeerMetadata, TrackMetadata>(
 
         if (client.status === "joined" && event.mediaDeviceType === "userMedia" && !pending) {
           if (!client.devices.microphone.broadcast?.stream && configRef.current.microphone.broadcastOnDeviceStart) {
-            console.log({ name: "broadcastOnMicrophoneStart-addTrack" });
-
             pending = true;
 
             await client.devices.microphone
@@ -435,16 +430,12 @@ export const create = <PeerMetadata, TrackMetadata>(
                 pending = false;
               });
           } else if (client.devices.microphone.broadcast?.stream && broadcastOnDeviceChange === "replace") {
-            console.log({ name: "broadcastOnMicrophoneStart-replaceTrack" });
-
             pending = true;
 
             await client.devices.microphone.replaceTrack().finally(() => {
               pending = false;
             });
           } else if (client.devices.microphone.broadcast?.stream && broadcastOnDeviceChange === "stop") {
-            console.log({ name: "broadcastOnMicrophoneStart-removeTrack" });
-
             pending = true;
 
             await client.devices.microphone.removeTrack().finally(() => {

--- a/src/create.tsx
+++ b/src/create.tsx
@@ -14,10 +14,10 @@ import { PeerStatus, TrackId, TrackWithOrigin } from "./state.types";
 import { ConnectConfig, CreateConfig } from "@fishjam-dev/ts-client";
 import {
   DeviceManagerConfig,
-  UseCameraAndMicrophoneResult,
-  UseCameraResult,
-  UseMicrophoneResult,
-  UseScreenShareResult,
+  Devices,
+  CameraAPI,
+  MicrophoneAPI,
+  ScreenShareAPI,
   UseSetupMediaConfig,
   UseSetupMediaResult,
 } from "./types";
@@ -42,9 +42,9 @@ export type CreateFishjamClient<PeerMetadata, TrackMetadata> = {
   useSelector: <Result>(selector: Selector<PeerMetadata, TrackMetadata, Result>) => Result;
   useTracks: () => Record<TrackId, TrackWithOrigin<PeerMetadata, TrackMetadata>>;
   useSetupMedia: (config: UseSetupMediaConfig<TrackMetadata>) => UseSetupMediaResult;
-  useCamera: () => UseCameraAndMicrophoneResult<TrackMetadata>["camera"];
-  useMicrophone: () => UseCameraAndMicrophoneResult<TrackMetadata>["microphone"];
-  useScreenShare: () => UseScreenShareResult<TrackMetadata>;
+  useCamera: () => Devices<TrackMetadata>["camera"];
+  useMicrophone: () => Devices<TrackMetadata>["microphone"];
+  useScreenShare: () => ScreenShareAPI<TrackMetadata>;
   useClient: () => Client<PeerMetadata, TrackMetadata>;
 };
 
@@ -249,13 +249,13 @@ export const create = <PeerMetadata, TrackMetadata>(
   const useTracks = () => useSelector((s) => s.tracks);
   const useClient = () => useSelector((s) => s.client);
 
-  const useCamera = (): UseCameraResult<TrackMetadata> => {
+  const useCamera = (): CameraAPI<TrackMetadata> => {
     const { state } = useFishjamContext();
 
     return state.devices.camera;
   };
 
-  const useMicrophone = (): UseMicrophoneResult<TrackMetadata> => {
+  const useMicrophone = (): MicrophoneAPI<TrackMetadata> => {
     const { state } = useFishjamContext();
 
     return state.devices.microphone;
@@ -589,7 +589,7 @@ export const create = <PeerMetadata, TrackMetadata>(
     );
   };
 
-  const useScreenShare = (): UseScreenShareResult<TrackMetadata> => {
+  const useScreenShare = (): ScreenShareAPI<TrackMetadata> => {
     const { state } = useFishjamContext();
     return state.devices.screenShare;
   };

--- a/src/create.tsx
+++ b/src/create.tsx
@@ -312,7 +312,7 @@ export const create = <PeerMetadata, TrackMetadata>(
             await client.devices.camera.replaceTrack().finally(() => {
               pending = false;
             });
-          } else if (client.devices.camera.broadcast?.stream && broadcastOnDeviceChange === "stop") {
+          } else if (client.devices.camera.broadcast?.stream && broadcastOnDeviceChange === "remove") {
             pending = true;
 
             await client.devices.camera.removeTrack().finally(() => {
@@ -427,7 +427,7 @@ export const create = <PeerMetadata, TrackMetadata>(
             await client.devices.microphone.replaceTrack().finally(() => {
               pending = false;
             });
-          } else if (client.devices.microphone.broadcast?.stream && broadcastOnDeviceChange === "stop") {
+          } else if (client.devices.microphone.broadcast?.stream && broadcastOnDeviceChange === "remove") {
             pending = true;
 
             await client.devices.microphone.removeTrack().finally(() => {

--- a/src/create.tsx
+++ b/src/create.tsx
@@ -296,7 +296,7 @@ export const create = <PeerMetadata, TrackMetadata>(
         event: { mediaDeviceType: MediaDeviceType },
         client: ClientApi<PeerMetadata, TrackMetadata>,
       ) => {
-        const broadcastOnDeviceChange = configRef.current.camera.broadcastOnDeviceChange ?? "replace";
+        const broadcastOnDeviceChange = configRef.current.camera.onDeviceChange ?? "replace";
 
         if (client.status === "joined" && event.mediaDeviceType === "userMedia" && !pending) {
           if (!client.devices.camera.broadcast?.stream && configRef.current.camera.broadcastOnDeviceStart) {
@@ -376,7 +376,13 @@ export const create = <PeerMetadata, TrackMetadata>(
           event.trackType === "video" &&
           client.devices.camera.broadcast?.stream
         ) {
-          await client.devices.camera.removeTrack();
+          const onDeviceStop = configRef.current.camera.onDeviceStop ?? "mute";
+
+          if (onDeviceStop === "mute") {
+            await client.devices.camera.muteTrack();
+          } else {
+            await client.devices.camera.removeTrack();
+          }
         }
       };
 
@@ -481,7 +487,7 @@ export const create = <PeerMetadata, TrackMetadata>(
     }, [state.client]);
 
     useEffect(() => {
-      const removeOnMicrophoneStopped: ClientEvents<PeerMetadata, TrackMetadata>["deviceStopped"] = async (
+      const onMicrophoneStopped: ClientEvents<PeerMetadata, TrackMetadata>["deviceStopped"] = async (
         event,
         client,
       ) => {
@@ -494,20 +500,17 @@ export const create = <PeerMetadata, TrackMetadata>(
           const onDeviceStop = configRef.current.microphone.onDeviceStop ?? "mute";
 
           if (onDeviceStop === "mute") {
-            console.log({ name: "removeOnMicrophoneStopped-replaceTrack" });
-
             await client.devices.microphone.muteTrack();
           } else {
-            console.log({ name: "removeOnMicrophoneStopped-removeTrack" });
             await client.devices.microphone.removeTrack();
           }
         }
       };
 
-      state.client.on("deviceStopped", removeOnMicrophoneStopped);
+      state.client.on("deviceStopped", onMicrophoneStopped);
 
       return () => {
-        state.client.removeListener("deviceStopped", removeOnMicrophoneStopped);
+        state.client.removeListener("deviceStopped", onMicrophoneStopped);
       };
     }, [state.client]);
 
@@ -563,7 +566,7 @@ export const create = <PeerMetadata, TrackMetadata>(
     }, [state.client]);
 
     useEffect(() => {
-      const removeOnScreenShareStopped: ClientEvents<PeerMetadata, TrackMetadata>["deviceStopped"] = async (
+      const onScreenShareStop: ClientEvents<PeerMetadata, TrackMetadata>["deviceStopped"] = async (
         event,
         client,
       ) => {
@@ -576,10 +579,10 @@ export const create = <PeerMetadata, TrackMetadata>(
         }
       };
 
-      state.client.on("deviceStopped", removeOnScreenShareStopped);
+      state.client.on("deviceStopped", onScreenShareStop);
 
       return () => {
-        state.client.removeListener("deviceStopped", removeOnScreenShareStopped);
+        state.client.removeListener("deviceStopped", onScreenShareStop);
       };
     }, [state.client]);
 

--- a/src/create.tsx
+++ b/src/create.tsx
@@ -478,10 +478,7 @@ export const create = <PeerMetadata, TrackMetadata>(
     }, [state.client]);
 
     useEffect(() => {
-      const onMicrophoneStopped: ClientEvents<PeerMetadata, TrackMetadata>["deviceStopped"] = async (
-        event,
-        client,
-      ) => {
+      const onMicrophoneStopped: ClientEvents<PeerMetadata, TrackMetadata>["deviceStopped"] = async (event, client) => {
         if (
           client.status === "joined" &&
           event.mediaDeviceType === "userMedia" &&
@@ -557,10 +554,7 @@ export const create = <PeerMetadata, TrackMetadata>(
     }, [state.client]);
 
     useEffect(() => {
-      const onScreenShareStop: ClientEvents<PeerMetadata, TrackMetadata>["deviceStopped"] = async (
-        event,
-        client,
-      ) => {
+      const onScreenShareStop: ClientEvents<PeerMetadata, TrackMetadata>["deviceStopped"] = async (event, client) => {
         if (
           client.status === "joined" &&
           event.mediaDeviceType === "displayMedia" &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,10 @@ export type {
 export type {
   DeviceManagerConfig,
   StorageConfig,
-  UseCameraAndMicrophoneResult,
-  UseCameraResult,
-  UseScreenShareResult,
-  UseMicrophoneResult,
+  Devices,
+  CameraAPI,
+  ScreenShareAPI,
+  MicrophoneAPI,
   UseSetupMediaResult,
   UseSetupMediaConfig,
 } from "./types";

--- a/src/state.types.ts
+++ b/src/state.types.ts
@@ -1,6 +1,6 @@
 import type { TrackEncoding, VadStatus, SimulcastConfig } from "@fishjam-dev/ts-client";
-import { UseUserMediaState } from "./types";
-import { UseCameraAndMicrophoneResult } from "./types";
+import { MediaState } from "./types";
+import { Devices } from "./types";
 import { Client } from "./Client";
 import { DeviceManager } from "./DeviceManager";
 import { ScreenShareManager } from "./ScreenShareManager";
@@ -48,8 +48,8 @@ export type State<PeerMetadata, TrackMetadata> = {
   tracks: Record<TrackId, TrackWithOrigin<PeerMetadata, TrackMetadata>>;
   bandwidthEstimation: bigint;
   status: PeerStatus;
-  media: UseUserMediaState | null;
-  devices: UseCameraAndMicrophoneResult<TrackMetadata>;
+  media: MediaState | null;
+  devices: Devices<TrackMetadata>;
   client: Client<PeerMetadata, TrackMetadata>;
   deviceManager: DeviceManager;
   screenShareManager: ScreenShareManager;

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,7 +170,7 @@ export type MicrophoneAPI<TrackMetadata> = {
   replaceTrack: (newTrackMetadata?: TrackMetadata) => Promise<void>;
   muteTrack: (newTrackMetadata?: TrackMetadata) => Promise<void>;
   unmuteTrack: (newTrackMetadata?: TrackMetadata) => Promise<void>;
-  updateTrackMetadata: (newTrackMetadata: TrackMetadata) => void
+  updateTrackMetadata: (newTrackMetadata: TrackMetadata) => void;
   broadcast: Track<TrackMetadata> | null;
   status: DevicesStatus | null;
   stream: MediaStream | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,12 +22,12 @@ export type DeviceState = {
   error: DeviceError | null;
 };
 
-export type UseUserMediaState = {
+export type MediaState = {
   video: DeviceState;
   audio: DeviceState;
 };
 
-export type InitMediaConfig = {
+export type DeviceManagerInitConfig = {
   videoTrackConstraints?: boolean | MediaTrackConstraints;
   audioTrackConstraints?: boolean | MediaTrackConstraints;
 };
@@ -46,7 +46,7 @@ export type StorageConfig = {
   saveLastVideoDevice: (info: MediaDeviceInfo) => void;
 };
 
-export type UseUserMediaStartConfig = {
+export type DeviceManagerStartConfig = {
   audioDeviceId?: string | boolean;
   videoDeviceId?: string | boolean;
 };
@@ -131,7 +131,7 @@ export type UseSetupMediaResult = {
   init: () => void;
 };
 
-export type UseCameraResult<TrackMetadata> = {
+export type CameraAPI<TrackMetadata> = {
   stop: () => void;
   setEnable: (value: boolean) => void;
   start: (deviceId?: string) => void;
@@ -153,7 +153,7 @@ export type UseCameraResult<TrackMetadata> = {
   devices: MediaDeviceInfo[] | null;
 };
 
-export type UseMicrophoneResult<TrackMetadata> = {
+export type MicrophoneAPI<TrackMetadata> = {
   stop: () => void;
   setEnable: (value: boolean) => void;
   start: (deviceId?: string) => void;
@@ -171,7 +171,7 @@ export type UseMicrophoneResult<TrackMetadata> = {
   devices: MediaDeviceInfo[] | null;
 };
 
-export type UseScreenShareResult<TrackMetadata> = {
+export type ScreenShareAPI<TrackMetadata> = {
   stop: () => void;
   setEnable: (value: boolean) => void;
   start: (config?: ScreenShareManagerConfig) => void;
@@ -187,12 +187,12 @@ export type UseScreenShareResult<TrackMetadata> = {
   error: DeviceError | null;
 };
 
-export type UseCameraAndMicrophoneResult<TrackMetadata> = {
-  camera: UseCameraResult<TrackMetadata>;
-  microphone: UseMicrophoneResult<TrackMetadata>;
-  screenShare: UseScreenShareResult<TrackMetadata>;
+export type Devices<TrackMetadata> = {
+  camera: CameraAPI<TrackMetadata>;
+  microphone: MicrophoneAPI<TrackMetadata>;
+  screenShare: ScreenShareAPI<TrackMetadata>;
   init: (config?: DeviceManagerConfig) => void;
-  start: (config: UseUserMediaStartConfig) => void;
+  start: (config: DeviceManagerStartConfig) => void;
 };
 
 export const PERMISSION_DENIED: DeviceError = { name: "NotAllowedError" };

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,10 +99,18 @@ export type UseSetupMediaConfig<TrackMetadata> = {
      */
     broadcastOnDeviceStart?: boolean;
     /**
-     * Determines whether track should be replaced when the user requests a device.
+     * Determines whether currently broadcasted track should be replaced or stopped
+     * when the user changed a device.
      * default: replace
      */
-    broadcastOnDeviceChange?: "replace" | "stop";
+    onDeviceChange?: "replace" | "stop";
+
+    /**
+     * Determines whether currently broadcasted track should be removed or muted
+     * when the user stopped a device.
+     * default: replace
+     */
+    onDeviceStop?: "remove" | "mute";
 
     trackConstraints: boolean | MediaTrackConstraints;
     defaultTrackMetadata?: TrackMetadata;
@@ -160,6 +168,9 @@ export type MicrophoneAPI<TrackMetadata> = {
   addTrack: (trackMetadata?: TrackMetadata, maxBandwidth?: TrackBandwidthLimit) => Promise<string>;
   removeTrack: () => Promise<void>;
   replaceTrack: (newTrackMetadata?: TrackMetadata) => Promise<void>;
+  muteTrack: (newTrackMetadata?: TrackMetadata) => Promise<void>;
+  unmuteTrack: (newTrackMetadata?: TrackMetadata) => Promise<void>;
+  updateTrackMetadata: (newTrackMetadata: TrackMetadata) => void
   broadcast: Track<TrackMetadata> | null;
   status: DevicesStatus | null;
   stream: MediaStream | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export type UseSetupMediaConfig<TrackMetadata> = {
      * Determines whether track should be replaced when the user requests a device.
      * default: replace
      */
-    onDeviceChange?: "replace" | "stop";
+    onDeviceChange?: "replace" | "remove";
     /**
      * Determines whether currently broadcasted track should be removed or muted
      * when the user stopped a device.
@@ -109,7 +109,7 @@ export type UseSetupMediaConfig<TrackMetadata> = {
      * when the user changed a device.
      * default: replace
      */
-    onDeviceChange?: "replace" | "stop";
+    onDeviceChange?: "replace" | "remove";
 
     /**
      * Determines whether currently broadcasted track should be removed or muted

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,13 @@ export type UseSetupMediaConfig<TrackMetadata> = {
      * Determines whether track should be replaced when the user requests a device.
      * default: replace
      */
-    broadcastOnDeviceChange?: "replace" | "stop";
+    onDeviceChange?: "replace" | "stop";
+    /**
+     * Determines whether currently broadcasted track should be removed or muted
+     * when the user stopped a device.
+     * default: replace
+     */
+    onDeviceStop?: "remove" | "mute";
 
     trackConstraints: boolean | MediaTrackConstraints;
     defaultTrackMetadata?: TrackMetadata;
@@ -150,6 +156,9 @@ export type CameraAPI<TrackMetadata> = {
   ) => Promise<string>;
   removeTrack: () => Promise<void>;
   replaceTrack: (newTrackMetadata?: TrackMetadata) => Promise<void>;
+  muteTrack: (newTrackMetadata?: TrackMetadata) => Promise<void>;
+  unmuteTrack: (newTrackMetadata?: TrackMetadata) => Promise<void>;
+  updateTrackMetadata: (newTrackMetadata: TrackMetadata) => void;
   broadcast: Track<TrackMetadata> | null;
   status: DevicesStatus | null; // todo how to remove null
   stream: MediaStream | null;


### PR DESCRIPTION
## Description

This PR introduces changes from: https://github.com/fishjam-dev/ts-client-sdk/pull/49 and also:

### useCamera, useMicrophone, useScreenshare

Hooks for managing a single track of a given type in the global state (similarly to the React Native API).

#### onDeviceStop

`onDeviceStop?: "remove" | "mute";
This PR introduces a new `onDeviceStop` config parameter that allows the user to decide what to do if a track stops. Without it, the track has been removed from `RTCPeerConnection`. Now, with the option `mute`, that track can be reused later without renegotiation. It is a companion event to `onDeviceChange`.

Added `onDeviceStop`, `onDeviceChange`, and the ability to stop a device to `use-camera-and-microphone-example`.

#### onDeviceChange

`onDeviceChange?: "replace" | "stop";`
Determines whether a track should be replaced when the user requests a device change. Previously, `broadcastOnDeviceChange`.

#### Other changes

- Names of types like `UseMicrophoneResult` changed to something simpler, like `MicrophoneAPI`.

## Motivation and Context

Fishjam now offers the ability to reuse tracks.

## Types of changes

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a fix or feature that would cause existing functionality to not work as expected)
  - The `replaceTrack` method can handle a nullable track parameter.
  - The `stream` parameter was removed from the `addTrack` method.