### PR TITLE
Add rule to use `import` and `import type` 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,22 +6,23 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier"
+    "prettier",
   ],
   "rules": {
-    "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "error",
-    "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       {
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_",
-        "caughtErrorsIgnorePattern": "^_"
-      }
+        "caughtErrorsIgnorePattern": "^_",
+      },
     ],
     "no-console": ["error", { "allow": ["warn", "error"] }],
-    "react-refresh/only-export-components": ["warn", { "allowConstantExport": true }]
-  }
+    "react-hooks/exhaustive-deps": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-refresh/only-export-components": ["warn", { "allowConstantExport": true }],
+  },
 }

--- a/examples/minimal-react/src/components/App.tsx
+++ b/examples/minimal-react/src/components/App.tsx
@@ -1,5 +1,6 @@
 import VideoPlayer from "./VideoPlayer";
-import { SCREEN_SHARING_MEDIA_CONSTRAINTS, Client } from "@fishjam-dev/react-client";
+import type { Client } from "@fishjam-dev/react-client";
+import { SCREEN_SHARING_MEDIA_CONSTRAINTS } from "@fishjam-dev/react-client";
 import { useState } from "react";
 import { useConnect, useDisconnect, useClient, useStatus, useTracks } from "./client";
 

--- a/examples/minimal-react/src/components/VideoPlayer.tsx
+++ b/examples/minimal-react/src/components/VideoPlayer.tsx
@@ -1,4 +1,5 @@
-import { RefObject, useEffect, useRef } from "react";
+import type { RefObject} from "react";
+import { useEffect, useRef } from "react";
 
 type Props = {
   stream: MediaStream | null | undefined;

--- a/examples/minimal-react/src/components/VideoPlayer.tsx
+++ b/examples/minimal-react/src/components/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import type { RefObject} from "react";
+import type { RefObject } from "react";
 import { useEffect, useRef } from "react";
 
 type Props = {

--- a/examples/minimal-react/src/components/client.ts
+++ b/examples/minimal-react/src/components/client.ts
@@ -1,5 +1,5 @@
 import { create } from "@fishjam-dev/react-client";
-import { PeerMetadata, TrackMetadata } from "./App";
+import type { PeerMetadata, TrackMetadata } from "./App";
 
 // Create a Membrane client instance
 // remember to use FishjamContextProvider

--- a/examples/use-camera-and-microphone-example/src/Badge.tsx
+++ b/examples/use-camera-and-microphone-example/src/Badge.tsx
@@ -1,4 +1,4 @@
-import { PeerStatus } from "@fishjam-dev/react-client";
+import type { PeerStatus } from "@fishjam-dev/react-client";
 
 type Props = {
   status: PeerStatus;

--- a/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
+++ b/examples/use-camera-and-microphone-example/src/DeviceControls.tsx
@@ -1,5 +1,5 @@
-import { PeerStatus, UseMicrophoneResult, UseCameraResult, UseScreenShareResult } from "@fishjam-dev/react-client";
-import { TrackMetadata } from "./fishjamSetup";
+import type { PeerStatus, UseMicrophoneResult, UseCameraResult, UseScreenShareResult } from "@fishjam-dev/react-client";
+import type { TrackMetadata } from "./fishjamSetup";
 
 type DeviceControlsProps = {
   status: PeerStatus;

--- a/examples/use-camera-and-microphone-example/src/DeviceSelector.tsx
+++ b/examples/use-camera-and-microphone-example/src/DeviceSelector.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent} from "react";
+import type { ChangeEvent } from "react";
 import { useState } from "react";
 
 type Props = {

--- a/examples/use-camera-and-microphone-example/src/DeviceSelector.tsx
+++ b/examples/use-camera-and-microphone-example/src/DeviceSelector.tsx
@@ -1,4 +1,5 @@
-import { ChangeEvent, useState } from "react";
+import type { ChangeEvent} from "react";
+import { useState } from "react";
 
 type Props = {
   name: string;

--- a/examples/use-camera-and-microphone-example/src/VideoPlayer.tsx
+++ b/examples/use-camera-and-microphone-example/src/VideoPlayer.tsx
@@ -1,4 +1,5 @@
-import { RefObject, useEffect, useRef } from "react";
+import type { RefObject} from "react";
+import { useEffect, useRef } from "react";
 
 type Props = {
   stream: MediaStream | null | undefined;

--- a/examples/use-camera-and-microphone-example/src/VideoPlayer.tsx
+++ b/examples/use-camera-and-microphone-example/src/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import type { RefObject} from "react";
+import type { RefObject } from "react";
 import { useEffect, useRef } from "react";
 
 type Props = {

--- a/examples/use-camera-and-microphone-example/src/fishjamSetup.tsx
+++ b/examples/use-camera-and-microphone-example/src/fishjamSetup.tsx
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ClientEvents} from "@fishjam-dev/react-client";
+import type { ClientEvents } from "@fishjam-dev/react-client";
 import { create } from "@fishjam-dev/react-client";
 import { useEffect, useState } from "react";
 

--- a/examples/use-camera-and-microphone-example/src/fishjamSetup.tsx
+++ b/examples/use-camera-and-microphone-example/src/fishjamSetup.tsx
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { ClientEvents, create } from "@fishjam-dev/react-client";
+import type { ClientEvents} from "@fishjam-dev/react-client";
+import { create } from "@fishjam-dev/react-client";
 import { useEffect, useState } from "react";
 
 const peerMetadataSchema = z.object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@jellyfish-dev/react-client-sdk",
+  "name": "@fishjam-dev/react-client",
   "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@jellyfish-dev/react-client-sdk",
+      "name": "@fishjam-dev/react-client",
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -11,10 +11,9 @@ import type {
   SimulcastConfig,
   TrackBandwidthLimit,
   TrackContext,
-  TrackEncoding} from "@fishjam-dev/ts-client";
-import {
-  FishjamClient
+  TrackEncoding,
 } from "@fishjam-dev/ts-client";
+import { FishjamClient } from "@fishjam-dev/ts-client";
 import type { PeerId, PeerState, PeerStatus, Track, TrackId, TrackWithOrigin } from "./state.types";
 import type { DeviceManagerEvents } from "./DeviceManager";
 import { DeviceManager } from "./DeviceManager";

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,23 +1,26 @@
 import EventEmitter from "events";
-import TypedEmitter from "typed-emitter";
-import {
+import type TypedEmitter from "typed-emitter";
+import type {
   AuthErrorReason,
   BandwidthLimit,
   Component,
   ConnectConfig,
   CreateConfig,
-  FishjamClient,
   MessageEvents,
   Peer,
   SimulcastConfig,
   TrackBandwidthLimit,
   TrackContext,
-  TrackEncoding,
-} from "@fishjam-dev/ts-client";
-import { PeerId, PeerState, PeerStatus, Track, TrackId, TrackWithOrigin } from "./state.types";
-import { DeviceManager, DeviceManagerEvents } from "./DeviceManager";
-import { MediaDeviceType, ScreenShareManager, ScreenShareManagerConfig } from "./ScreenShareManager";
+  TrackEncoding} from "@fishjam-dev/ts-client";
 import {
+  FishjamClient
+} from "@fishjam-dev/ts-client";
+import type { PeerId, PeerState, PeerStatus, Track, TrackId, TrackWithOrigin } from "./state.types";
+import type { DeviceManagerEvents } from "./DeviceManager";
+import { DeviceManager } from "./DeviceManager";
+import type { MediaDeviceType, ScreenShareManagerConfig } from "./ScreenShareManager";
+import { ScreenShareManager } from "./ScreenShareManager";
+import type {
   DeviceManagerConfig,
   DeviceState,
   InitMediaConfig,

--- a/src/DeviceManager.ts
+++ b/src/DeviceManager.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AudioOrVideoType,
   CurrentDevices,
   DeviceError,
@@ -9,13 +9,14 @@ import {
   GetMedia,
   InitMediaConfig,
   Media,
+  StorageConfig,
+  UseUserMediaStartConfig} from "./types";
+import {
   NOT_FOUND_ERROR,
   OVERCONSTRAINED_ERROR,
   parseError,
   PERMISSION_DENIED,
-  StorageConfig,
-  UNHANDLED_ERROR,
-  UseUserMediaStartConfig,
+  UNHANDLED_ERROR
 } from "./types";
 
 import { loadObject, saveObject } from "./localStorage";
@@ -27,8 +28,8 @@ import {
 } from "./constraints";
 
 import EventEmitter from "events";
-import TypedEmitter from "typed-emitter";
-import { TrackType } from "./ScreenShareManager";
+import type TypedEmitter from "typed-emitter";
+import type { TrackType } from "./ScreenShareManager";
 
 const removeExact = (
   trackConstraints: boolean | MediaTrackConstraints | undefined,

--- a/src/DeviceManager.ts
+++ b/src/DeviceManager.ts
@@ -10,14 +10,9 @@ import type {
   InitMediaConfig,
   Media,
   StorageConfig,
-  UseUserMediaStartConfig} from "./types";
-import {
-  NOT_FOUND_ERROR,
-  OVERCONSTRAINED_ERROR,
-  parseError,
-  PERMISSION_DENIED,
-  UNHANDLED_ERROR
+  UseUserMediaStartConfig,
 } from "./types";
+import { NOT_FOUND_ERROR, OVERCONSTRAINED_ERROR, parseError, PERMISSION_DENIED, UNHANDLED_ERROR } from "./types";
 
 import { loadObject, saveObject } from "./localStorage";
 import {

--- a/src/ScreenShareManager.ts
+++ b/src/ScreenShareManager.ts
@@ -1,6 +1,6 @@
 import EventEmitter from "events";
 import type TypedEmitter from "typed-emitter";
-import type { AudioOrVideoType, DeviceError, DevicesStatus} from "./types";
+import type { AudioOrVideoType, DeviceError, DevicesStatus } from "./types";
 import { parseError } from "./types";
 
 export type TrackType = "audio" | "video" | "audiovideo";

--- a/src/ScreenShareManager.ts
+++ b/src/ScreenShareManager.ts
@@ -1,6 +1,7 @@
 import EventEmitter from "events";
-import TypedEmitter from "typed-emitter";
-import { AudioOrVideoType, DeviceError, DevicesStatus, parseError } from "./types";
+import type TypedEmitter from "typed-emitter";
+import type { AudioOrVideoType, DeviceError, DevicesStatus} from "./types";
+import { parseError } from "./types";
 
 export type TrackType = "audio" | "video" | "audiovideo";
 export type MediaDeviceType = "displayMedia" | "userMedia";

--- a/src/create.tsx
+++ b/src/create.tsx
@@ -1,15 +1,5 @@
-import type {
-  JSX,
-  ReactNode} from "react";
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useSyncExternalStore,
-} from "react";
+import type { JSX, ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import type { Selector, State } from "./state.types";
 import type { PeerStatus, TrackId, TrackWithOrigin } from "./state.types";
 import type { ConnectConfig, CreateConfig } from "@fishjam-dev/ts-client";

--- a/src/create.tsx
+++ b/src/create.tsx
@@ -1,7 +1,8 @@
+import type {
+  JSX,
+  ReactNode} from "react";
 import {
   createContext,
-  JSX,
-  ReactNode,
   useCallback,
   useContext,
   useEffect,
@@ -10,9 +11,9 @@ import {
   useSyncExternalStore,
 } from "react";
 import type { Selector, State } from "./state.types";
-import { PeerStatus, TrackId, TrackWithOrigin } from "./state.types";
-import { ConnectConfig, CreateConfig } from "@fishjam-dev/ts-client";
-import {
+import type { PeerStatus, TrackId, TrackWithOrigin } from "./state.types";
+import type { ConnectConfig, CreateConfig } from "@fishjam-dev/ts-client";
+import type {
   DeviceManagerConfig,
   UseCameraAndMicrophoneResult,
   UseCameraResult,
@@ -21,8 +22,9 @@ import {
   UseSetupMediaConfig,
   UseSetupMediaResult,
 } from "./types";
-import { Client, ClientApi, ClientEvents } from "./Client";
-import { MediaDeviceType, ScreenShareManagerConfig } from "./ScreenShareManager";
+import type { ClientApi, ClientEvents } from "./Client";
+import { Client } from "./Client";
+import type { MediaDeviceType, ScreenShareManagerConfig } from "./ScreenShareManager";
 
 export type FishjamContextProviderProps = {
   children: ReactNode;

--- a/src/state.types.ts
+++ b/src/state.types.ts
@@ -1,9 +1,9 @@
 import type { TrackEncoding, VadStatus, SimulcastConfig } from "@fishjam-dev/ts-client";
-import { UseUserMediaState } from "./types";
-import { UseCameraAndMicrophoneResult } from "./types";
-import { Client } from "./Client";
-import { DeviceManager } from "./DeviceManager";
-import { ScreenShareManager } from "./ScreenShareManager";
+import type { UseUserMediaState } from "./types";
+import type { UseCameraAndMicrophoneResult } from "./types";
+import type { Client } from "./Client";
+import type { DeviceManager } from "./DeviceManager";
+import type { ScreenShareManager } from "./ScreenShareManager";
 
 export type TrackId = string;
 export type PeerId = string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-import { SimulcastConfig, TrackBandwidthLimit } from "@fishjam-dev/ts-client";
-import { ScreenShareManagerConfig } from "./ScreenShareManager";
-import { Track } from "./state.types";
+import type { SimulcastConfig, TrackBandwidthLimit } from "@fishjam-dev/ts-client";
+import type { ScreenShareManagerConfig } from "./ScreenShareManager";
+import type { Track } from "./state.types";
 
 export type AudioOrVideoType = "audio" | "video";
 

--- a/tests/globalSetupState.ts
+++ b/tests/globalSetupState.ts
@@ -1,4 +1,4 @@
-import { StartedDockerComposeEnvironment } from "testcontainers";
+import type { StartedDockerComposeEnvironment } from "testcontainers";
 
 export type SetupState = {
   fishjamContainer: StartedDockerComposeEnvironment | null;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,4 @@
-import type { Page} from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 export const joinRoomAndAddScreenShare = async (page: Page, roomId: string): Promise<string> =>

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,5 @@
-import { expect, Page, test } from "@playwright/test";
+import type { Page} from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 export const joinRoomAndAddScreenShare = async (page: Page, roomId: string): Promise<string> =>
   test.step("Join room and add track", async () => {


### PR DESCRIPTION
This PR just adds rule `@typescript-eslint/consistent-type-imports` in eslint. 
(also sorts rules in .eslintrc and fixes code using `yarn lint:fix`)

This rule helps understand if imported thing is just type, or part of actual logic.